### PR TITLE
fix: exclude jsx runtime from output

### DIFF
--- a/.changeset/rotten-jokes-think.md
+++ b/.changeset/rotten-jokes-think.md
@@ -1,0 +1,5 @@
+---
+"slick-toc": patch
+---
+
+fix: exclude react/jsx-runtime from build output

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: ["react", "react-dom", "react-jsx-runtime.production"],
+      external: ["react", "react-dom", "react/jsx-runtime"],
       output: {
         // Provide global variables to use in the UMD build
         // for externalized deps


### PR DESCRIPTION
Closes #17 